### PR TITLE
feat: extend the list of supported types of plain text documents

### DIFF
--- a/aidial_adapter_anthropic/adapter/_claude/adapter.py
+++ b/aidial_adapter_anthropic/adapter/_claude/adapter.py
@@ -88,7 +88,7 @@ from aidial_adapter_anthropic.adapter._base import (
 from aidial_adapter_anthropic.adapter._claude.blocks import (
     IMAGE_ATTACHMENT_PROCESSOR,
     PDF_ATTACHMENT_PROCESSOR,
-    TEXT_ATTACHMENT_PROCESSOR,
+    PLAIN_TEXT_ATTACHMENT_PROCESSOR,
     create_text_block,
 )
 from aidial_adapter_anthropic.adapter._claude.citations import create_citations
@@ -227,7 +227,7 @@ class Adapter(ChatCompletionAdapter):
     def attachment_processors(self) -> AttachmentProcessors:
         # Document support: https://docs.anthropic.com/en/docs/build-with-claude/pdf-support#supported-platforms-and-models
         document_processors = (
-            [PDF_ATTACHMENT_PROCESSOR, TEXT_ATTACHMENT_PROCESSOR]
+            [PDF_ATTACHMENT_PROCESSOR, PLAIN_TEXT_ATTACHMENT_PROCESSOR]
             if self.supports_documents
             else []
         )

--- a/aidial_adapter_anthropic/adapter/_claude/blocks.py
+++ b/aidial_adapter_anthropic/adapter/_claude/blocks.py
@@ -50,7 +50,7 @@ def create_text_document_block(
     return RequestDocumentBlockParam(
         source=PlainTextSourceParam(
             data=resource.data.decode("utf-8"),
-            media_type=resource.type,  # type: ignore
+            media_type="text/plain",
             type="text",
         ),
         type="document",
@@ -64,7 +64,7 @@ def create_pdf_document_block(
     return RequestDocumentBlockParam(
         source=Base64PDFSourceParam(
             data=resource.data_base64,
-            media_type=resource.type,  # type: ignore
+            media_type="application/pdf",
             type="base64",
         ),
         type="document",
@@ -106,7 +106,23 @@ PDF_ATTACHMENT_PROCESSOR = AttachmentProcessor(
     handler=create_pdf_document_block,
 )
 
-TEXT_ATTACHMENT_PROCESSOR = AttachmentProcessor(
-    supported_types={"text/plain": {"txt"}},
+PLAIN_TEXT_ATTACHMENT_PROCESSOR = AttachmentProcessor(
+    supported_types={
+        "text/plain": {"txt"},
+        "text/html": {"html", "htm"},
+        "text/css": {"css"},
+        "text/javascript": {"js"},
+        "application/x-javascript": {"js"},
+        "text/x-typescript": {"ts"},
+        "application/x-typescript": {"ts"},
+        "text/csv": {"csv"},
+        "text/markdown": {"md"},
+        "text/x-python": {"py"},
+        "application/x-python-code": {"py"},
+        "application/json": {"json"},
+        "text/xml": {"xml"},
+        "application/rtf": {"rtf"},
+        "text/rtf": {"rtf"},
+    },
     handler=create_text_document_block,
 )


### PR DESCRIPTION
Porting the [fix](https://github.com/epam/ai-dial-adapter-bedrock/pull/383) from the Bedrock adapter to the package.