### PR TITLE
chore(ci): add release candidate branching

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -5,10 +5,16 @@ on:
     types:
       - opened
       - edited
-      - synchronize
+      - reopened
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@3.2.0
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.0.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches: [development, release-*]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/python_package_pr.yml@3.2.0
+    uses: epam/ai-dial-ci/.github/workflows/python_package_pr.yml@4.0.0
     secrets: inherit
     with:
       python-version: "3.11"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,23 @@ name: Release Workflow
 on:
   push:
     branches: [development, release-*]
+  workflow_dispatch:
+    inputs:
+      promote:
+        type: boolean
+        default: false
+        description: Promote release to stable (for release-* branches only)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/python_package_release.yml@3.2.0
-    secrets: inherit
+    uses: epam/ai-dial-ci/.github/workflows/python_package_release.yml@4.0.0
     with:
+      promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
       python-version: "3.11"
       poetry-version: "2.2.1"
       code-checks-python-versions: '["3.11", "3.12", "3.13"]'
+    secrets: inherit

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request }}
     steps:
       - name: Slash Command Dispatch
         id: scd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aidial-adapter-anthropic"
-version = "0.7.0rc"
+version = "0.0.0"
 description = "Package implementing adapter from DIAL Chat Completions API to Anthropic API"
 authors = [{ name = "EPAM RAIL", email = "SpecialEPM-DIALDevTeam@epam.com" }]
 license = "Apache-2.0"

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,13 +1,14 @@
 # Trivy configuration file
 # https://aquasecurity.github.io/trivy/latest/docs/references/configuration/config-file/
-# Can be deleted after public ecr mirror will be added by default
 db:
   no-progress: true
   repository:
-    - ghcr.io/aquasecurity/trivy-db:2
+    - mirror.gcr.io/aquasec/trivy-db:2
     - public.ecr.aws/aquasecurity/trivy-db:2
+    - ghcr.io/aquasecurity/trivy-db:2
   java-repository:
-    - ghcr.io/aquasecurity/trivy-java-db:1
+    - mirror.gcr.io/aquasec/trivy-java-db:1
     - public.ecr.aws/aquasecurity/trivy-java-db:1
+    - ghcr.io/aquasecurity/trivy-java-db:1
 misconfiguration:
-  checks-bundle-repository: public.ecr.aws/aquasecurity/trivy-checks
+  checks-bundle-repository: mirror.gcr.io/aquasec/trivy-checks:1


### PR DESCRIPTION
- bump epam/ai-dial-ci workflow version and add promote input = enable release candidates for the given repo
- drop version in pyproject.toml file to dev marker (`0.0.0`)
- align additional Trivy configuration with reference
- minor workflow-related fixes & alignments