### PR TITLE
chore(ci): always produce stable versions on release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches: [development, release-*]
   workflow_dispatch:
-    inputs:
-      promote:
-        type: boolean
-        default: false
-        description: Promote release to stable (for release-* branches only)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,8 +13,8 @@ jobs:
   release:
     uses: epam/ai-dial-ci/.github/workflows/python_package_release.yml@4.0.0
     with:
-      promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
+      promote: true # HACK: skip RC phase, project does not require stabilization period before releasing stable versions
       python-version: "3.11"
       poetry-version: "2.2.1"
-      code-checks-python-versions: '["3.11", "3.12", "3.13"]'
+      code-checks-python-versions: "[\"3.11\", \"3.12\", \"3.13\"]"
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,5 +16,5 @@ jobs:
       promote: true # HACK: skip RC phase, project does not require stabilization period before releasing stable versions
       python-version: "3.11"
       poetry-version: "2.2.1"
-      code-checks-python-versions: "[\"3.11\", \"3.12\", \"3.13\"]"
+      code-checks-python-versions: '["3.11", "3.12", "3.13"]'
     secrets: inherit


### PR DESCRIPTION
- Hardcode promote input so RC phase will be skipped, effectively producing stable versions on every push to `release-*` branches