### PR TITLE
fix: enable DIAL caching

### DIFF
--- a/aidial_adapter_anthropic/adapter/_claude/adapter.py
+++ b/aidial_adapter_anthropic/adapter/_claude/adapter.py
@@ -126,6 +126,9 @@ from aidial_adapter_anthropic.adapter._claude.tools import (
     process_tools_block,
 )
 from aidial_adapter_anthropic.adapter._decorator.base import compose_decorators
+from aidial_adapter_anthropic.adapter._decorator.caching import (
+    caching_decorator,
+)
 from aidial_adapter_anthropic.adapter._decorator.preprocess import (
     preprocess_messages_decorator,
 )
@@ -219,6 +222,7 @@ async def create_adapter(
     return compose_decorators(
         preprocess_messages_decorator(default_preprocess_messages),
         replicator_decorator(),
+        caching_decorator(),
     )(model)
 
 

--- a/aidial_adapter_anthropic/adapter/_claude/caching.py
+++ b/aidial_adapter_anthropic/adapter/_claude/caching.py
@@ -13,7 +13,7 @@ _DEFAULT_TTL_SEC = 5 * 60
 
 def _parse_ttl(ttl: str) -> int | None:
     try:
-        for unit, secs in {"h": 3600, "m": 60}.items():
+        for unit, secs in {"h": 3600, "m": 60, "s": 1}.items():
             if ttl[-1] == unit:
                 return secs * int(ttl[:-1])
     except Exception:

--- a/aidial_adapter_anthropic/adapter/_claude/caching.py
+++ b/aidial_adapter_anthropic/adapter/_claude/caching.py
@@ -1,0 +1,56 @@
+import time
+
+from aidial_sdk.chat_completion import CacheBreakpoint
+from aidial_sdk.chat_completion import Message as DialMessage
+
+_DIAL_CACHE_BREAKPOINT_PATH = "X-DIAL-CACHE-BREAKPOINT-PATH"
+_DIAL_CACHE_EXPIRE_AT = "X-DIAL-CACHE-EXPIRE-AT"
+
+# 5min is a default TTL for Clade cache breakpoints
+# https://platform.claude.com/docs/en/build-with-claude/prompt-caching#ttl-support
+_DEFAULT_TTL_SEC = 5 * 60
+
+
+def _parse_ttl(ttl: str) -> int | None:
+    try:
+        for unit, secs in {"h": 3600, "m": 60}.items():
+            if ttl[-1] == unit:
+                return secs * int(ttl[:-1])
+    except Exception:
+        return None
+
+
+def _ttl_from_breakpoint(breakpoint: CacheBreakpoint) -> int:
+    s = (breakpoint.model_extra or {}).get("ttl")
+    if s and isinstance(s, str) and (ttl := _parse_ttl(s)):
+        return ttl
+    return _DEFAULT_TTL_SEC
+
+
+def get_response_headers_for_caching(
+    automatic_cache_breakpoint: CacheBreakpoint | None,
+    messages: list[DialMessage],
+) -> dict | None:
+    if automatic_cache_breakpoint is not None:
+        ttl = _ttl_from_breakpoint(automatic_cache_breakpoint)
+        idx = len(messages) - 1
+    else:
+        max_ttl = 0
+        last_idx = None
+        for i, message in enumerate(messages):
+            if (
+                (cf := message.custom_fields)
+                and (breakpoint := cf.cache_breakpoint)
+                and (msg_ttl := _ttl_from_breakpoint(breakpoint))
+            ):
+                max_ttl = max(max_ttl, msg_ttl)
+                last_idx = i
+
+        if last_idx is not None:
+            ttl = max_ttl
+            idx = last_idx
+
+    return {
+        _DIAL_CACHE_BREAKPOINT_PATH: f"prefix.body.messages[{idx}]",
+        _DIAL_CACHE_EXPIRE_AT: str(int(time.time()) + ttl),
+    }

--- a/aidial_adapter_anthropic/adapter/_claude/caching.py
+++ b/aidial_adapter_anthropic/adapter/_claude/caching.py
@@ -31,14 +31,16 @@ def _ttl_from_breakpoint(breakpoint: CacheBreakpoint) -> int:
 def get_response_headers_for_caching(
     automatic_cache_breakpoint: CacheBreakpoint | None,
     messages: list[DialMessage],
-    tools: list[DialTool] | None = None,
+    tools: list[DialTool],
 ) -> dict | None:
     ttl = 0
-    path = None
+    automatic_path = None
+    message_path = None
+    tool_path = None
 
     if automatic_cache_breakpoint is not None:
         ttl = _ttl_from_breakpoint(automatic_cache_breakpoint)
-        path = f"prefix.body.messages[{len(messages) - 1}]"
+        automatic_path = f"prefix.body.messages[{len(messages) - 1}]"
 
     for i, message in enumerate(messages):
         if (
@@ -47,16 +49,18 @@ def get_response_headers_for_caching(
             and (msg_ttl := _ttl_from_breakpoint(breakpoint))
         ):
             ttl = max(ttl, msg_ttl)
-            path = f"prefix.body.messages[{i}]"
+            message_path = f"prefix.body.messages[{i}]"
 
-    for i, tool in enumerate(tools or []):
+    for i, tool in enumerate(tools):
         if (
             (cf := tool.custom_fields)
             and (breakpoint := cf.cache_breakpoint)
             and (tool_ttl := _ttl_from_breakpoint(breakpoint))
         ):
             ttl = max(ttl, tool_ttl)
-            path = f"prefix.body.tools[{i}]"
+            tool_path = f"prefix.body.tools[{i}]"
+
+    path = automatic_path or message_path or tool_path
 
     if path is None:
         return None

--- a/aidial_adapter_anthropic/adapter/_claude/caching.py
+++ b/aidial_adapter_anthropic/adapter/_claude/caching.py
@@ -2,6 +2,7 @@ import time
 
 from aidial_sdk.chat_completion import CacheBreakpoint
 from aidial_sdk.chat_completion import Message as DialMessage
+from aidial_sdk.chat_completion import Tool as DialTool
 
 _DIAL_CACHE_BREAKPOINT_PATH = "X-DIAL-CACHE-BREAKPOINT-PATH"
 _DIAL_CACHE_EXPIRE_AT = "X-DIAL-CACHE-EXPIRE-AT"
@@ -30,13 +31,14 @@ def _ttl_from_breakpoint(breakpoint: CacheBreakpoint) -> int:
 def get_response_headers_for_caching(
     automatic_cache_breakpoint: CacheBreakpoint | None,
     messages: list[DialMessage],
+    tools: list[DialTool] | None = None,
 ) -> dict | None:
     ttl = 0
-    idx = None
+    path = None
 
     if automatic_cache_breakpoint is not None:
         ttl = _ttl_from_breakpoint(automatic_cache_breakpoint)
-        idx = len(messages) - 1
+        path = f"prefix.body.messages[{len(messages) - 1}]"
 
     for i, message in enumerate(messages):
         if (
@@ -45,12 +47,21 @@ def get_response_headers_for_caching(
             and (msg_ttl := _ttl_from_breakpoint(breakpoint))
         ):
             ttl = max(ttl, msg_ttl)
-            idx = max(idx or 0, i)
+            path = f"prefix.body.messages[{i}]"
 
-    if idx is None:
+    for i, tool in enumerate(tools or []):
+        if (
+            (cf := tool.custom_fields)
+            and (breakpoint := cf.cache_breakpoint)
+            and (tool_ttl := _ttl_from_breakpoint(breakpoint))
+        ):
+            ttl = max(ttl, tool_ttl)
+            path = f"prefix.body.tools[{i}]"
+
+    if path is None:
         return None
 
     return {
-        _DIAL_CACHE_BREAKPOINT_PATH: f"prefix.body.messages[{idx}]",
+        _DIAL_CACHE_BREAKPOINT_PATH: path,
         _DIAL_CACHE_EXPIRE_AT: str(int(time.time()) + ttl),
     }

--- a/aidial_adapter_anthropic/adapter/_claude/caching.py
+++ b/aidial_adapter_anthropic/adapter/_claude/caching.py
@@ -31,23 +31,24 @@ def get_response_headers_for_caching(
     automatic_cache_breakpoint: CacheBreakpoint | None,
     messages: list[DialMessage],
 ) -> dict | None:
+    ttl = 0
+    idx = None
+
     if automatic_cache_breakpoint is not None:
         ttl = _ttl_from_breakpoint(automatic_cache_breakpoint)
         idx = len(messages) - 1
-    else:
-        ttl = 0
-        idx = None
-        for i, message in enumerate(messages):
-            if (
-                (cf := message.custom_fields)
-                and (breakpoint := cf.cache_breakpoint)
-                and (msg_ttl := _ttl_from_breakpoint(breakpoint))
-            ):
-                ttl = max(ttl, msg_ttl)
-                idx = i
 
-        if idx is None:
-            return None
+    for i, message in enumerate(messages):
+        if (
+            (cf := message.custom_fields)
+            and (breakpoint := cf.cache_breakpoint)
+            and (msg_ttl := _ttl_from_breakpoint(breakpoint))
+        ):
+            ttl = max(ttl, msg_ttl)
+            idx = max(idx or 0, i)
+
+    if idx is None:
+        return None
 
     return {
         _DIAL_CACHE_BREAKPOINT_PATH: f"prefix.body.messages[{idx}]",

--- a/aidial_adapter_anthropic/adapter/_claude/caching.py
+++ b/aidial_adapter_anthropic/adapter/_claude/caching.py
@@ -35,20 +35,19 @@ def get_response_headers_for_caching(
         ttl = _ttl_from_breakpoint(automatic_cache_breakpoint)
         idx = len(messages) - 1
     else:
-        max_ttl = 0
-        last_idx = None
+        ttl = 0
+        idx = None
         for i, message in enumerate(messages):
             if (
                 (cf := message.custom_fields)
                 and (breakpoint := cf.cache_breakpoint)
                 and (msg_ttl := _ttl_from_breakpoint(breakpoint))
             ):
-                max_ttl = max(max_ttl, msg_ttl)
-                last_idx = i
+                ttl = max(ttl, msg_ttl)
+                idx = i
 
-        if last_idx is not None:
-            ttl = max_ttl
-            idx = last_idx
+        if idx is None:
+            return None
 
     return {
         _DIAL_CACHE_BREAKPOINT_PATH: f"prefix.body.messages[{idx}]",

--- a/aidial_adapter_anthropic/adapter/_decorator/caching.py
+++ b/aidial_adapter_anthropic/adapter/_decorator/caching.py
@@ -25,8 +25,9 @@ class CachingDecorator(ChatCompletionDecorator):
         params: ModelParameters,
         messages: list[Message],
     ) -> None:
+        tools = params.tool_config.tools if params.tool_config else None
         if headers := get_response_headers_for_caching(
-            params.cache_breakpoint, messages
+            params.cache_breakpoint, messages, tools
         ):
             await consumer.set_response_headers(headers)
         await self.adapter.chat(consumer, params, messages)

--- a/aidial_adapter_anthropic/adapter/_decorator/caching.py
+++ b/aidial_adapter_anthropic/adapter/_decorator/caching.py
@@ -25,7 +25,7 @@ class CachingDecorator(ChatCompletionDecorator):
         params: ModelParameters,
         messages: list[Message],
     ) -> None:
-        tools = params.tool_config.tools if params.tool_config else None
+        tools = params.tool_config.tools if params.tool_config else []
         if headers := get_response_headers_for_caching(
             params.cache_breakpoint, messages, tools
         ):

--- a/aidial_adapter_anthropic/adapter/_decorator/caching.py
+++ b/aidial_adapter_anthropic/adapter/_decorator/caching.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+
+from aidial_sdk.chat_completion import Message
+
+from aidial_adapter_anthropic.adapter._claude.caching import (
+    get_response_headers_for_caching,
+)
+from aidial_adapter_anthropic.adapter._decorator.base import (
+    ChatCompletionDecorator,
+    ChatCompletionTransformer,
+)
+from aidial_adapter_anthropic.dial.consumer import Consumer
+from aidial_adapter_anthropic.dial.request import ModelParameters
+
+
+def caching_decorator() -> ChatCompletionTransformer:
+    return lambda adapter: CachingDecorator(adapter=adapter)
+
+
+@dataclass
+class CachingDecorator(ChatCompletionDecorator):
+    async def chat(
+        self,
+        consumer: Consumer,
+        params: ModelParameters,
+        messages: list[Message],
+    ) -> None:
+        if headers := get_response_headers_for_caching(
+            params.cache_breakpoint, messages
+        ):
+            await consumer.set_response_headers(headers)
+        await self.adapter.chat(consumer, params, messages)

--- a/aidial_adapter_anthropic/dial/consumer.py
+++ b/aidial_adapter_anthropic/dial/consumer.py
@@ -54,6 +54,9 @@ class Consumer(AbstractAsyncContextManager, ABC):
     ): ...
 
     @abstractmethod
+    async def set_response_headers(self, headers: dict[str, str]): ...
+
+    @abstractmethod
     async def append_content(self, content: str): ...
 
     @abstractmethod
@@ -179,6 +182,10 @@ class ChoiceConsumer(Consumer):
             self._response_state.flush(self.response)
 
         return False
+
+    async def set_response_headers(self, headers: dict[str, str]):
+        for k, v in headers.items():
+            self.response.append_header(k, v)
 
     async def close_content(self, finish_reason: FinishReason | None = None):
         # Choice.close(finish_reason: Optional[FinishReason]) can be called only once

--- a/tests/unit_tests/test_dial_caching.py
+++ b/tests/unit_tests/test_dial_caching.py
@@ -303,3 +303,23 @@ async def test_adapter_chat_prefers_last_message_path_over_automatic_breakpoint(
         (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.messages[1]"),
         (_DIAL_CACHE_EXPIRE_AT, "4600"),
     ]
+
+
+async def test_adapter_chat_sets_headers_for_last_tool_breakpoint(
+    adapter: ChatCompletionAdapter,
+):
+    consumer = await _invoke_chat(
+        adapter,
+        {
+            "messages": [_user("What's the weather?")],
+            "tools": [
+                _tool(),
+                _tool(cache_breakpoint={"ttl": "5m"}),
+            ],
+        },
+    )
+
+    assert consumer.response.headers == [
+        (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.tools[1]"),
+        (_DIAL_CACHE_EXPIRE_AT, "1300"),
+    ]

--- a/tests/unit_tests/test_dial_caching.py
+++ b/tests/unit_tests/test_dial_caching.py
@@ -60,36 +60,34 @@ async def adapter() -> ChatCompletionAdapter:
     )
 
 
+@pytest.fixture(autouse=True)
+def mock_current_time_1000s(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(caching_module.time, "time", lambda: 1000)
+
+
+@pytest.fixture(autouse=True)
+def mock_adapter_chat(monkeypatch: pytest.MonkeyPatch):
+    async def _fake_chat(*args, **kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(Adapter, "chat", _fake_chat)
+
+
 async def _invoke_chat(
     adapter: ChatCompletionAdapter,
-    monkeypatch: pytest.MonkeyPatch,
     request: dict,
 ) -> ChoiceConsumer:
     req = _request(request)
     consumer = ChoiceConsumer(_response(req))
-
-    async def _fake_chat(
-        self: Adapter,
-        consumer: ChoiceConsumer,
-        params: ModelParameters,
-        messages: list,
-    ) -> None:
-        return None
-
-    monkeypatch.setattr(Adapter, "chat", _fake_chat)
     await adapter.chat(consumer, ModelParameters.create(req), req.messages)
     return consumer
 
 
 async def test_adapter_chat_sets_headers_for_top_level_breakpoint(
     adapter: ChatCompletionAdapter,
-    monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setattr(caching_module.time, "time", lambda: 1000)
-
     consumer = await _invoke_chat(
         adapter,
-        monkeypatch,
         {
             "messages": [_user("first"), _user("second")],
             "custom_fields": {"cache_breakpoint": {"ttl": "1h"}},
@@ -104,13 +102,9 @@ async def test_adapter_chat_sets_headers_for_top_level_breakpoint(
 
 async def test_adapter_chat_sets_headers_for_last_message_breakpoint(
     adapter: ChatCompletionAdapter,
-    monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setattr(caching_module.time, "time", lambda: 1000)
-
     consumer = await _invoke_chat(
         adapter,
-        monkeypatch,
         {
             "messages": [
                 _user("first", cache_breakpoint={"ttl": "1h"}),
@@ -128,11 +122,9 @@ async def test_adapter_chat_sets_headers_for_last_message_breakpoint(
 
 async def test_adapter_chat_does_not_set_headers_without_breakpoints(
     adapter: ChatCompletionAdapter,
-    monkeypatch: pytest.MonkeyPatch,
 ):
     consumer = await _invoke_chat(
         adapter,
-        monkeypatch,
         {"messages": [_user("first"), _user("second")]},
     )
 

--- a/tests/unit_tests/test_dial_caching.py
+++ b/tests/unit_tests/test_dial_caching.py
@@ -29,6 +29,33 @@ def _user(content: str, *, cache_breakpoint: dict | None = None) -> dict:
     return msg
 
 
+def _sys(content: str, *, cache_breakpoint: dict | None = None) -> dict:
+    msg: dict = {"role": "system", "content": content}
+    if cache_breakpoint is not None:
+        msg["custom_fields"] = {"cache_breakpoint": cache_breakpoint}
+    return msg
+
+
+def _tool(cache_breakpoint: dict | None = None) -> dict:
+    tool: dict = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                },
+                "required": ["location"],
+            },
+        },
+    }
+    if cache_breakpoint is not None:
+        tool["custom_fields"] = {"cache_breakpoint": cache_breakpoint}
+    return tool
+
+
 def _request(request: dict) -> ChatCompletionRequest:
     return ChatCompletionRequest.model_validate(request)
 
@@ -129,3 +156,95 @@ async def test_adapter_chat_does_not_set_headers_without_breakpoints(
     )
 
     assert consumer.response.headers == []
+
+
+async def test_adapter_chat_sets_headers_for_system_message_breakpoint(
+    adapter: ChatCompletionAdapter,
+):
+    consumer = await _invoke_chat(
+        adapter,
+        {
+            "messages": [
+                _sys("be helpful", cache_breakpoint={"ttl": "5m"}),
+                _user("hello"),
+            ]
+        },
+    )
+
+    assert consumer.response.headers == [
+        (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.messages[0]"),
+        (_DIAL_CACHE_EXPIRE_AT, "1300"),
+    ]
+
+
+async def test_adapter_chat_uses_default_ttl_for_automatic_breakpoint(
+    adapter: ChatCompletionAdapter,
+):
+    consumer = await _invoke_chat(
+        adapter,
+        {
+            "messages": [_user("first"), _user("second")],
+            "custom_fields": {"cache_breakpoint": {}},
+        },
+    )
+
+    assert consumer.response.headers == [
+        (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.messages[1]"),
+        (_DIAL_CACHE_EXPIRE_AT, "1300"),
+    ]
+
+
+async def test_adapter_chat_uses_max_ttl_across_automatic_and_message_breakpoints(
+    adapter: ChatCompletionAdapter,
+):
+    consumer = await _invoke_chat(
+        adapter,
+        {
+            "messages": [
+                _user("first"),
+                _user("second", cache_breakpoint={"ttl": "1h"}),
+            ],
+            "custom_fields": {"cache_breakpoint": {"ttl": "5m"}},
+        },
+    )
+
+    assert consumer.response.headers == [
+        (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.messages[1]"),
+        (_DIAL_CACHE_EXPIRE_AT, "4600"),
+    ]
+
+
+async def test_adapter_chat_sets_headers_for_tool_breakpoint(
+    adapter: ChatCompletionAdapter,
+):
+    consumer = await _invoke_chat(
+        adapter,
+        {
+            "messages": [_user("What's the weather?")],
+            "tools": [_tool(cache_breakpoint={})],
+        },
+    )
+
+    assert consumer.response.headers == [
+        (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.tools[0]"),
+        (_DIAL_CACHE_EXPIRE_AT, "1300"),
+    ]
+
+
+async def test_adapter_chat_uses_default_ttl_for_invalid_breakpoint_ttl(
+    adapter: ChatCompletionAdapter,
+):
+    consumer = await _invoke_chat(
+        adapter,
+        {
+            "messages": [
+                _user("first"),
+                _user("second", cache_breakpoint={"ttl": "invalid"}),
+            ]
+        },
+    )
+
+    assert consumer.response.headers == [
+        (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.messages[1]"),
+        (_DIAL_CACHE_EXPIRE_AT, "1300"),
+    ]

--- a/tests/unit_tests/test_dial_caching.py
+++ b/tests/unit_tests/test_dial_caching.py
@@ -248,3 +248,58 @@ async def test_adapter_chat_uses_default_ttl_for_invalid_breakpoint_ttl(
         (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.messages[1]"),
         (_DIAL_CACHE_EXPIRE_AT, "1300"),
     ]
+
+
+async def test_adapter_chat_prefers_message_path_over_tool_breakpoint(
+    adapter: ChatCompletionAdapter,
+):
+    consumer = await _invoke_chat(
+        adapter,
+        {
+            "tools": [_tool(cache_breakpoint={"ttl": "1h"})],
+            "messages": [_user("first", cache_breakpoint={"ttl": "5m"})],
+        },
+    )
+
+    assert consumer.response.headers == [
+        (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.messages[0]"),
+        (_DIAL_CACHE_EXPIRE_AT, "4600"),
+    ]
+
+
+async def test_adapter_chat_prefers_automatic_message_path_over_tool_breakpoint(
+    adapter: ChatCompletionAdapter,
+):
+    consumer = await _invoke_chat(
+        adapter,
+        {
+            "tools": [_tool(cache_breakpoint={"ttl": "1h"})],
+            "messages": [_user("first"), _user("second")],
+            "custom_fields": {"cache_breakpoint": {"ttl": "5m"}},
+        },
+    )
+
+    assert consumer.response.headers == [
+        (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.messages[1]"),
+        (_DIAL_CACHE_EXPIRE_AT, "4600"),
+    ]
+
+
+async def test_adapter_chat_prefers_last_message_path_over_automatic_breakpoint(
+    adapter: ChatCompletionAdapter,
+):
+    consumer = await _invoke_chat(
+        adapter,
+        {
+            "messages": [
+                _user("first", cache_breakpoint={"ttl": "5m"}),
+                _user("second"),
+            ],
+            "custom_fields": {"cache_breakpoint": {"ttl": "1h"}},
+        },
+    )
+
+    assert consumer.response.headers == [
+        (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.messages[1]"),
+        (_DIAL_CACHE_EXPIRE_AT, "4600"),
+    ]

--- a/tests/unit_tests/test_dial_caching.py
+++ b/tests/unit_tests/test_dial_caching.py
@@ -1,0 +1,139 @@
+import anthropic
+import pytest
+from aidial_sdk.chat_completion import Response
+from aidial_sdk.chat_completion.request import (
+    ChatCompletionRequest,
+    Request,
+)
+from pydantic import SecretStr
+from starlette.requests import Request as StarletteRequest
+
+from aidial_adapter_anthropic.adapter import ChatCompletionAdapter
+from aidial_adapter_anthropic.adapter._claude import caching as caching_module
+from aidial_adapter_anthropic.adapter._claude.adapter import Adapter
+from aidial_adapter_anthropic.adapter._claude.tokenizer import (
+    ApproximateTokenizer,
+)
+from aidial_adapter_anthropic.adapter.claude import create_adapter
+from aidial_adapter_anthropic.dial.consumer import ChoiceConsumer
+from aidial_adapter_anthropic.dial.request import ModelParameters
+
+_DIAL_CACHE_BREAKPOINT_PATH = "X-DIAL-CACHE-BREAKPOINT-PATH"
+_DIAL_CACHE_EXPIRE_AT = "X-DIAL-CACHE-EXPIRE-AT"
+
+
+def _user(content: str, *, cache_breakpoint: dict | None = None) -> dict:
+    msg: dict = {"role": "user", "content": content}
+    if cache_breakpoint is not None:
+        msg["custom_fields"] = {"cache_breakpoint": cache_breakpoint}
+    return msg
+
+
+def _request(request: dict) -> ChatCompletionRequest:
+    return ChatCompletionRequest.model_validate(request)
+
+
+def _response(request: ChatCompletionRequest) -> Response:
+    return Response(
+        Request(
+            headers={},
+            api_key_secret=SecretStr("test"),
+            deployment_id="test-deployment",
+            original_request=StarletteRequest(
+                {"type": "http", "method": "POST", "path": "/", "headers": []}
+            ),
+            **request.model_dump(exclude_none=True),
+        )
+    )
+
+
+@pytest.fixture
+async def adapter() -> ChatCompletionAdapter:
+    return await create_adapter(
+        deployment="test-deployment",
+        storage=None,
+        client=anthropic.AsyncAnthropic(),
+        custom_tokenizer=ApproximateTokenizer(),
+        default_max_tokens=1024,
+        supports_thinking=True,
+        supports_documents=True,
+    )
+
+
+async def _invoke_chat(
+    adapter: ChatCompletionAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+    request: dict,
+) -> ChoiceConsumer:
+    req = _request(request)
+    consumer = ChoiceConsumer(_response(req))
+
+    async def _fake_chat(
+        self: Adapter,
+        consumer: ChoiceConsumer,
+        params: ModelParameters,
+        messages: list,
+    ) -> None:
+        return None
+
+    monkeypatch.setattr(Adapter, "chat", _fake_chat)
+    await adapter.chat(consumer, ModelParameters.create(req), req.messages)
+    return consumer
+
+
+async def test_adapter_chat_sets_headers_for_top_level_breakpoint(
+    adapter: ChatCompletionAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(caching_module.time, "time", lambda: 1000)
+
+    consumer = await _invoke_chat(
+        adapter,
+        monkeypatch,
+        {
+            "messages": [_user("first"), _user("second")],
+            "custom_fields": {"cache_breakpoint": {"ttl": "1h"}},
+        },
+    )
+
+    assert consumer.response.headers == [
+        (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.messages[1]"),
+        (_DIAL_CACHE_EXPIRE_AT, "4600"),
+    ]
+
+
+async def test_adapter_chat_sets_headers_for_last_message_breakpoint(
+    adapter: ChatCompletionAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(caching_module.time, "time", lambda: 1000)
+
+    consumer = await _invoke_chat(
+        adapter,
+        monkeypatch,
+        {
+            "messages": [
+                _user("first", cache_breakpoint={"ttl": "1h"}),
+                _user("second"),
+                _user("third", cache_breakpoint={"ttl": "5m"}),
+            ]
+        },
+    )
+
+    assert consumer.response.headers == [
+        (_DIAL_CACHE_BREAKPOINT_PATH, "prefix.body.messages[2]"),
+        (_DIAL_CACHE_EXPIRE_AT, "4600"),
+    ]
+
+
+async def test_adapter_chat_does_not_set_headers_without_breakpoints(
+    adapter: ChatCompletionAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    consumer = await _invoke_chat(
+        adapter,
+        monkeypatch,
+        {"messages": [_user("first"), _user("second")]},
+    )
+
+    assert consumer.response.headers == []


### PR DESCRIPTION
The adapter returns the headers required to enable caching on the DIAL Core side:

* `X-DIAL-CACHE-BREAKPOINT-PATH`: the last path having cache breakpoint; for the automatic caching - the last message
* `X-DIAL-CACHE-EXPIRE-AT`: max of all TTL in the request