### PR TITLE
feat: Bedrock: support Mantle client

### DIFF
--- a/aidial_adapter_anthropic/adapter/_claude/adapter.py
+++ b/aidial_adapter_anthropic/adapter/_claude/adapter.py
@@ -8,6 +8,7 @@ from aidial_sdk.chat_completion import Message as DialMessage
 from anthropic import (
     AsyncAnthropic,
     AsyncAnthropicBedrock,
+    AsyncAnthropicBedrockMantle,
     AsyncAnthropicFoundry,
     AsyncAnthropicVertex,
     Omit,
@@ -194,6 +195,7 @@ class ClaudeRequest:
 AnthropicClient = (
     AsyncAnthropic
     | AsyncAnthropicBedrock
+    | AsyncAnthropicBedrockMantle
     | AsyncAnthropicVertex
     | AsyncAnthropicFoundry
 )

--- a/aidial_adapter_anthropic/adapter/_claude/tokenizer/anthropic.py
+++ b/aidial_adapter_anthropic/adapter/_claude/tokenizer/anthropic.py
@@ -4,6 +4,7 @@ from aidial_sdk.exceptions import InternalServerError
 from anthropic import (
     AsyncAnthropic,
     AsyncAnthropicBedrock,
+    AsyncAnthropicBedrockMantle,
     AsyncAnthropicFoundry,
     AsyncAnthropicVertex,
 )
@@ -16,6 +17,7 @@ from aidial_adapter_anthropic.adapter._claude.params import ClaudeParameters
 AnthropicClient = (
     AsyncAnthropic
     | AsyncAnthropicBedrock
+    | AsyncAnthropicBedrockMantle
     | AsyncAnthropicVertex
     | AsyncAnthropicFoundry
 )


### PR DESCRIPTION
Required for: https://github.com/epam/ai-dial-adapter-bedrock/pull/447

## Summary
- Added support for `AsyncAnthropicBedrockMantle` in the Claude adapter client type alias.

## Why
- Types mismatch when passing Mantle client to `create_adapter()`.