### PR TITLE
feat: make anthropic-beta header adaptation customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The Bedrock backends require `botocore`, which is an optional dependency:
 pip install aidial-adapter-anthropic[bedrock]
 ```
 
-For Bedrock, `anthropic-beta` flags that Bedrock does not support are stripped automatically so the upstream does not reject the request. Endpoints a backend does not implement (e.g. Bedrock has no token-counting or batches route) surface as a `404` error.
+Endpoints a backend does not implement (e.g. Bedrock has no token-counting or batches route) surface as a `404` error.
 
 ---
 

--- a/aidial_adapter_anthropic/passthrough/__init__.py
+++ b/aidial_adapter_anthropic/passthrough/__init__.py
@@ -22,6 +22,7 @@ from starlette.applications import Starlette
 from aidial_adapter_anthropic.passthrough._proxy import (
     AnthropicClient,
     ClientFactory,
+    ClientT,
     OnAnthropicBetaHeader,
     create_anthropic_api_app,
 )
@@ -37,11 +38,11 @@ __all__ = [
 
 def mount_anthropic_api(
     app: Starlette,
-    get_client: ClientFactory,
+    get_client: ClientFactory[ClientT],
     *,
     path: str = "/anthropic",
     name: str = "Claude API passthrough",
-    on_anthropic_beta_header: OnAnthropicBetaHeader | None = None,
+    on_anthropic_beta_header: OnAnthropicBetaHeader[ClientT] | None = None,
 ) -> None:
     passthrough_app = create_anthropic_api_app(
         get_client, on_anthropic_beta_header=on_anthropic_beta_header

--- a/aidial_adapter_anthropic/passthrough/__init__.py
+++ b/aidial_adapter_anthropic/passthrough/__init__.py
@@ -22,12 +22,14 @@ from starlette.applications import Starlette
 from aidial_adapter_anthropic.passthrough._proxy import (
     AnthropicClient,
     ClientFactory,
+    OnAnthropicBetaHeader,
     create_anthropic_api_app,
 )
 
 __all__ = [
     "AnthropicClient",
     "ClientFactory",
+    "OnAnthropicBetaHeader",
     "create_anthropic_api_app",
     "mount_anthropic_api",
 ]
@@ -39,14 +41,9 @@ def mount_anthropic_api(
     *,
     path: str = "/anthropic",
     name: str = "Claude API passthrough",
+    on_anthropic_beta_header: OnAnthropicBetaHeader | None = None,
 ) -> None:
-    """Mount the Anthropic API passthrough onto a host application.
-
-    ``app`` is any Starlette/FastAPI app (e.g. a ``DIALApp``); ``get_client``
-    supplies the upstream Anthropic client to use for each request.
-    """
-    app.mount(
-        path=path,
-        app=create_anthropic_api_app(get_client),
-        name=name,
+    passthrough_app = create_anthropic_api_app(
+        get_client, on_anthropic_beta_header=on_anthropic_beta_header
     )
+    app.mount(path=path, app=passthrough_app, name=name)

--- a/aidial_adapter_anthropic/passthrough/_helpers.py
+++ b/aidial_adapter_anthropic/passthrough/_helpers.py
@@ -87,61 +87,22 @@ def strip_content_headers(response_headers: httpx.Headers) -> None:
     response_headers.pop("Content-Length", None)
 
 
-# Bedrock does not support these Anthropic beta flags; passing them through
-# would make the upstream reject the request, so they are stripped.
-_UNSUPPORTED_BEDROCK_ANTHROPIC_BETA_FLAGS = {
-    "oauth-2025-04-20",
-    "redact-thinking-2026-02-12",
-    "thinking-token-count-2026-05-13",
-    "prompt-caching-scope-2026-01-05",
-    "claude-code-20250219",
-    "advisor-tool-2026-03-01",
-}
-
-
-def _adapt_anthropic_beta_for_bedrock(value: str | None) -> str | None:
-    if value is None:
-        return None
-    features = [
-        feature
-        for feature in value.split(",")
-        if feature not in _UNSUPPORTED_BEDROCK_ANTHROPIC_BETA_FLAGS
-    ]
-    return ",".join(features) or None
-
-
-def _on_dict_value(
-    dct: dict[str, str],
-    key: str,
-    func: Callable[[str | None], str | None],
-) -> dict[str, str]:
-    value = func(dct.get(key))
-    if value is None:
-        dct.pop(key, None)
-    else:
-        dct[key] = value
-    return dct
-
-
-def build_request_headers(
-    headers: StarletteHeaders, *, is_bedrock: bool
-) -> dict[str, str]:
-    """Select the request headers that must reach the upstream.
-
-    Only Anthropic-specific headers and the encoding-control header are
-    forwarded; everything else (host, auth added by the client, etc.) is
-    dropped. Bedrock-unsupported beta flags are additionally stripped.
-    """
-
+def build_request_headers(headers: StarletteHeaders) -> dict[str, str]:
     def _keep_header(header: str) -> bool:
         header = header.lower()
         return header.startswith("anthropic-") or header == "accept-encoding"
 
-    result = {k.lower(): v for (k, v) in headers.items() if _keep_header(k)}
+    return {k.lower(): v for (k, v) in headers.items() if _keep_header(k)}
 
-    if is_bedrock:
-        result = _on_dict_value(
-            result, "anthropic-beta", _adapt_anthropic_beta_for_bedrock
-        )
 
-    return result
+def apply_anthropic_beta_features(
+    headers: dict[str, str],
+    transform: Callable[[list[str]], list[str]],
+) -> None:
+    raw = headers.get("anthropic-beta")
+    features = [f for f in raw.split(",") if f] if raw else []
+    features = transform(features)
+    if features:
+        headers["anthropic-beta"] = ",".join(features)
+    else:
+        headers.pop("anthropic-beta", None)

--- a/aidial_adapter_anthropic/passthrough/_proxy.py
+++ b/aidial_adapter_anthropic/passthrough/_proxy.py
@@ -16,6 +16,7 @@ import json
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from functools import partial
+from typing import TypeVar
 
 import httpx
 from anthropic import (
@@ -52,11 +53,9 @@ AnthropicClient = (
     | AsyncAnthropicFoundry
 )
 
-ClientFactory = (
-    Callable[[Request], Awaitable[AnthropicClient]] | AnthropicClient
-)
-
-OnAnthropicBetaHeader = Callable[[AnthropicClient, list[str]], list[str]]
+ClientT = TypeVar("ClientT", bound=AnthropicClient)
+ClientFactory = Callable[[Request], Awaitable[ClientT]] | ClientT
+OnAnthropicBetaHeader = Callable[[ClientT, list[str]], list[str]]
 
 
 @anthropic_response_decorator
@@ -65,7 +64,7 @@ async def _proxy(
     request: Request,
     path: str,
     client: AnthropicClient,
-    on_anthropic_beta_header: OnAnthropicBetaHeader | None,
+    on_anthropic_beta_header: OnAnthropicBetaHeader[AnthropicClient] | None,
 ) -> Response:
     json_body = None
     if content := await request.body():
@@ -136,8 +135,8 @@ async def _proxy(
 
 def _create_proxy_handler(
     path: str,
-    get_client: ClientFactory,
-    on_anthropic_beta_header: OnAnthropicBetaHeader | None,
+    get_client: ClientFactory[ClientT],
+    on_anthropic_beta_header: OnAnthropicBetaHeader[ClientT] | None,
 ) -> Callable[[Request], Awaitable[Response]]:
     async def handler(request: Request) -> Response:
         client = (
@@ -158,9 +157,9 @@ _PROXIED_ENDPOINTS = [
 
 
 def create_anthropic_api_app(
-    get_client: ClientFactory,
+    get_client: ClientFactory[ClientT],
     *,
-    on_anthropic_beta_header: OnAnthropicBetaHeader | None = None,
+    on_anthropic_beta_header: OnAnthropicBetaHeader[ClientT] | None = None,
 ) -> FastAPI:
     app = FastAPI()
     for method, path in _PROXIED_ENDPOINTS:

--- a/aidial_adapter_anthropic/passthrough/_proxy.py
+++ b/aidial_adapter_anthropic/passthrough/_proxy.py
@@ -15,6 +15,7 @@ import contextlib
 import json
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
+from functools import partial
 
 import httpx
 from anthropic import (
@@ -32,6 +33,7 @@ from aidial_adapter_anthropic.passthrough._errors import (
     anthropic_response_decorator,
 )
 from aidial_adapter_anthropic.passthrough._helpers import (
+    apply_anthropic_beta_features,
     bedrock_stream_to_sse,
     build_request_headers,
     is_streaming_request,
@@ -54,11 +56,16 @@ ClientFactory = (
     Callable[[Request], Awaitable[AnthropicClient]] | AnthropicClient
 )
 
+OnAnthropicBetaHeader = Callable[[AnthropicClient, list[str]], list[str]]
+
 
 @anthropic_response_decorator
 @logging_decorator
 async def _proxy(
-    request: Request, path: str, client: AnthropicClient
+    request: Request,
+    path: str,
+    client: AnthropicClient,
+    on_anthropic_beta_header: OnAnthropicBetaHeader | None,
 ) -> Response:
     json_body = None
     if content := await request.body():
@@ -67,10 +74,13 @@ async def _proxy(
 
     is_streaming = is_streaming_request(json_body, path)
 
-    is_bedrock = isinstance(
-        client, (AsyncAnthropicBedrock | AsyncAnthropicBedrockMantle)
-    )
-    headers = build_request_headers(request.headers, is_bedrock=is_bedrock)
+    headers = build_request_headers(request.headers)
+
+    if on_anthropic_beta_header is not None:
+        apply_anthropic_beta_features(
+            headers, partial(on_anthropic_beta_header, client)
+        )
+
     if _log.isEnabledFor(logging.DEBUG):
         # Ask the upstream not to compress the response so its body (and
         # streamed chunks) can be logged as-is. Forgoing compression on the
@@ -125,7 +135,9 @@ async def _proxy(
 
 
 def _create_proxy_handler(
-    path: str, get_client: ClientFactory
+    path: str,
+    get_client: ClientFactory,
+    on_anthropic_beta_header: OnAnthropicBetaHeader | None,
 ) -> Callable[[Request], Awaitable[Response]]:
     async def handler(request: Request) -> Response:
         client = (
@@ -133,7 +145,7 @@ def _create_proxy_handler(
             if isinstance(get_client, AnthropicClient)
             else await get_client(request)
         )
-        return await _proxy(request, path, client)
+        return await _proxy(request, path, client, on_anthropic_beta_header)
 
     return handler
 
@@ -145,12 +157,18 @@ _PROXIED_ENDPOINTS = [
 ]
 
 
-def create_anthropic_api_app(get_client: ClientFactory) -> FastAPI:
+def create_anthropic_api_app(
+    get_client: ClientFactory,
+    *,
+    on_anthropic_beta_header: OnAnthropicBetaHeader | None = None,
+) -> FastAPI:
     app = FastAPI()
     for method, path in _PROXIED_ENDPOINTS:
         app.router.add_api_route(
             path=path,
             methods=[method],
-            endpoint=_create_proxy_handler(path, get_client),
+            endpoint=_create_proxy_handler(
+                path, get_client, on_anthropic_beta_header
+            ),
         )
     return app

--- a/tests/unit_tests/anthropic_mocks.py
+++ b/tests/unit_tests/anthropic_mocks.py
@@ -82,9 +82,6 @@ class AnthropicMocker(ABC):
     # proxy decodes and re-encodes as SSE; every other backend relays SSE bytes
     # verbatim.
     reencodes_stream: ClassVar[bool] = False
-    # Bedrock backends (legacy and Mantle) drop the anthropic-beta flags they
-    # don't support; every other backend forwards the header untouched.
-    is_bedrock: ClassVar[bool] = False
     router: respx.MockRouter
 
     @classmethod
@@ -229,7 +226,6 @@ class AnthropicFoundryMocker(AnthropicMocker):
 
 class AnthropicMantleMocker(AnthropicMocker):
     id = "bedrock-mantle"
-    is_bedrock = True
 
     @classmethod
     def create(cls) -> Self:
@@ -270,7 +266,6 @@ class AnthropicBedrockLegacyMocker(AnthropicMocker):
     supports_count_tokens = False
     supports_batches = False
     reencodes_stream = True
-    is_bedrock = True
 
     @classmethod
     def create(cls) -> Self:

--- a/tests/unit_tests/test_passthrough.py
+++ b/tests/unit_tests/test_passthrough.py
@@ -309,8 +309,7 @@ class TestRequestHeaderPassthrough:
 
         assert response.status_code == 200
         upstream_headers = mocker.router.calls.last.request.headers
-        # Anthropic-specific headers must reach the upstream (this flag survives
-        # Bedrock adaptation too).
+        # Anthropic-specific headers must reach the upstream.
         assert (
             upstream_headers["anthropic-beta"]
             == "token-efficient-tools-2025-02-19"
@@ -335,21 +334,16 @@ class TestAnthropicBetaAdaptation:
 
         mocker.mock(_Mock())
 
-    async def test_http_client(
+    async def test_default_forwards_header_untouched(
         self, mocker: AnthropicMocker, http_client: httpx.AsyncClient
     ):
+        # Without a custom on_anthropic_beta_header the package performs no
+        # feature adaptation: the header reaches every backend verbatim.
         beta_header = (
             "oauth-2025-04-20,"
             "token-efficient-tools-2025-02-19,"
             "thinking-token-count-2026-05-13"
         )
-        # Bedrock strips the flags it doesn't support (only the unknown flag
-        # survives); every other backend forwards the header untouched.
-        expected_beta_header = (
-            "token-efficient-tools-2025-02-19"
-            if mocker.is_bedrock
-            else beta_header
-        )
 
         response = await http_client.post(
             "/v1/messages",
@@ -359,28 +353,54 @@ class TestAnthropicBetaAdaptation:
 
         assert response.status_code == 200
         upstream_headers = mocker.router.calls.last.request.headers
-        assert upstream_headers["anthropic-beta"] == expected_beta_header
+        assert upstream_headers["anthropic-beta"] == beta_header
 
-    async def test_http_client_drops_all_unsupported_header(
-        self, mocker: AnthropicMocker, http_client: httpx.AsyncClient
+    async def test_custom_handler_rewrites_features(
+        self, mocker: AnthropicMocker
     ):
-        # When every flag is Bedrock-unsupported, Bedrock drops the header
-        # entirely rather than forwarding it empty; other backends forward it
-        # untouched.
-        beta_header = "oauth-2025-04-20,thinking-token-count-2026-05-13"
+        # The handler receives the upstream client and the parsed feature list,
+        # and the list it returns is forwarded (here: one flag dropped).
+        seen: dict[str, object] = {}
 
-        response = await http_client.post(
-            "/v1/messages",
-            json=_MESSAGES_REQUEST,
-            headers={"anthropic-beta": beta_header},
+        def on_beta(client, features: list[str]) -> list[str]:
+            seen["client"] = client
+            seen["features"] = list(features)
+            return [f for f in features if f != "drop-me"]
+
+        client = mocker.make_client()
+        app = create_anthropic_api_app(client, on_anthropic_beta_header=on_beta)
+        async with _asgi_client(app) as http_client:
+            response = await http_client.post(
+                "/v1/messages",
+                json=_MESSAGES_REQUEST,
+                headers={"anthropic-beta": "keep-me,drop-me"},
+            )
+
+        assert response.status_code == 200
+        assert seen["client"] is client
+        assert seen["features"] == ["keep-me", "drop-me"]
+        upstream_headers = mocker.router.calls.last.request.headers
+        assert upstream_headers["anthropic-beta"] == "keep-me"
+
+    async def test_custom_handler_dropping_all_removes_header(
+        self, mocker: AnthropicMocker
+    ):
+        # An empty result drops the header entirely rather than forwarding an
+        # empty anthropic-beta (which the upstream would reject).
+        app = create_anthropic_api_app(
+            mocker.make_client(),
+            on_anthropic_beta_header=lambda client, features: [],
         )
+        async with _asgi_client(app) as http_client:
+            response = await http_client.post(
+                "/v1/messages",
+                json=_MESSAGES_REQUEST,
+                headers={"anthropic-beta": "oauth-2025-04-20"},
+            )
 
         assert response.status_code == 200
         upstream_headers = mocker.router.calls.last.request.headers
-        if mocker.is_bedrock:
-            assert "anthropic-beta" not in upstream_headers
-        else:
-            assert upstream_headers["anthropic-beta"] == beta_header
+        assert "anthropic-beta" not in upstream_headers
 
 
 class TestErrorPassthrough:


### PR DESCRIPTION
Follow-up of https://github.com/epam/ai-dial-adapter-anthropic/pull/70

## Summary

Replaces the hardcoded Bedrock `anthropic-beta` flag stripping in the API passthrough with an optional `on_anthropic_beta_header` callback.

- The callback receives the upstream `AnthropicClient` and the parsed feature list, and returns the list to forward.
- When no callback is supplied, the `anthropic-beta` header reaches every backend verbatim (no adaptation).
- An empty result drops the header entirely rather than forwarding an empty value.

This lets host applications adapt beta flags per backend as they see fit, instead of baking Bedrock-specific knowledge into the library.

## Testing

- `poetry run pytest tests/unit_tests/test_passthrough.py` (105 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)