### PR TITLE
feat!: Claude: enable web search via static tool instead of configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ A cache breakpoint may include an optional `ttl` field. Supported values are `5m
 
 Web search gives Claude direct access to real-time web content, allowing it to answer questions with up-to-date information beyond its knowledge cutoff. It is an Anthropic server-side tool: the searches are executed on Anthropic's side, and the final response includes citations for the sources used. See [Web search tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool) in the Anthropic docs.
 
-To enable web search, set `custom_fields.configuration.web_search` to the Anthropic web search tool definition.
+To enable web search, add a static tool named `web_search` to the request's `tools` list. The Anthropic web search tool definition goes into `static_function.configuration`; the `name` is defaulted from the static function, so you don't have to repeat it. Being a server-side tool, web search never forces a `tool_choice` and can be combined with ordinary function tools.
 
 <details><summary>Enable web search</summary>
 
@@ -238,14 +238,17 @@ To enable web search, set `custom_fields.configuration.web_search` to the Anthro
   "messages": [
     {"role": "user", "content": "What is the weather in NYC?"}
   ],
-  "custom_fields": {
-    "configuration": {
-      "web_search": {
-        "type": "web_search_20250305",
-        "name": "web_search"
+  "tools": [
+    {
+      "type": "static_function",
+      "static_function": {
+        "name": "web_search",
+        "configuration": {
+          "type": "web_search_20250305"
+        }
       }
     }
-  }
+  ]
 }
 ```
 
@@ -261,23 +264,26 @@ The tool definition supports optional fields such as `max_uses`, `allowed_domain
   "messages": [
     {"role": "user", "content": "What is the weather in San Francisco?"}
   ],
-  "custom_fields": {
-    "configuration": {
-      "web_search": {
-        "type": "web_search_20250305",
+  "tools": [
+    {
+      "type": "static_function",
+      "static_function": {
         "name": "web_search",
-        "max_uses": 5,
-        "allowed_domains": ["example.com", "trusteddomain.org"],
-        "user_location": {
-          "type": "approximate",
-          "city": "San Francisco",
-          "region": "California",
-          "country": "US",
-          "timezone": "America/Los_Angeles"
+        "configuration": {
+          "type": "web_search_20250305",
+          "max_uses": 5,
+          "allowed_domains": ["example.com", "trusteddomain.org"],
+          "user_location": {
+            "type": "approximate",
+            "city": "San Francisco",
+            "region": "California",
+            "country": "US",
+            "timezone": "America/Los_Angeles"
+          }
         }
       }
     }
-  }
+  ]
 }
 ```
 

--- a/aidial_adapter_anthropic/adapter/_claude/adapter.py
+++ b/aidial_adapter_anthropic/adapter/_claude/adapter.py
@@ -75,7 +75,6 @@ from anthropic.types.beta import (
 )
 from anthropic.types.beta import BetaThinkingBlock as ThinkingBlock
 from anthropic.types.beta import BetaThinkingConfigParam as ThinkingConfigParam
-from anthropic.types.beta import BetaToolParam as ToolParam
 from anthropic.types.beta import (
     BetaToolSearchToolResultBlock as ToolSearchToolResultBlock,
 )
@@ -120,10 +119,7 @@ from aidial_adapter_anthropic.adapter._claude.converters import (
     to_dial_finish_reason,
     to_dial_usage,
 )
-from aidial_adapter_anthropic.adapter._claude.params import (
-    ClaudeParameters,
-    WebSearchToolParam,
-)
+from aidial_adapter_anthropic.adapter._claude.params import ClaudeParameters
 from aidial_adapter_anthropic.adapter._claude.state import MessageState
 from aidial_adapter_anthropic.adapter._claude.tokenizer import (
     AnthropicTokenizer,
@@ -314,11 +310,7 @@ class Adapter(ChatCompletionAdapter):
 
         tools_config = to_claude_tool_config(params.tool_config)
 
-        tools: list[ToolParam | WebSearchToolParam] = list(
-            tools_config.tools if tools_config else []
-        )
-        if (web_search := configuration.web_search) is not None:
-            tools.append(web_search)
+        tools = list(tools_config.tools) if tools_config else []
 
         parsed_messages = [
             function_to_tool_messages(parse_dial_message(m)) for m in messages
@@ -373,7 +365,8 @@ class Adapter(ChatCompletionAdapter):
             temperature=temperature,
             top_p=top_p or omit,
             tools=tools or omit,
-            tool_choice=(tools_config and tools_config.tool_choice) or omit,
+            tool_choice=(tools_config.tool_choice if tools_config else None)
+            or omit,
             thinking=thinking,
             betas=configuration.betas or omit,
             output_config=output_config or omit,

--- a/aidial_adapter_anthropic/adapter/_claude/config.py
+++ b/aidial_adapter_anthropic/adapter/_claude/config.py
@@ -4,8 +4,6 @@ from anthropic.types.anthropic_beta_param import AnthropicBetaParam
 from anthropic.types.beta import BetaThinkingConfigParam as ThinkingConfigParam
 from pydantic import BaseModel, ConfigDict, Field
 
-from aidial_adapter_anthropic.adapter._claude.params import WebSearchToolParam
-
 ClaudeEffort = Literal["low", "medium", "high", "xhigh", "max"]
 
 
@@ -19,13 +17,6 @@ class ClaudeConfiguration(ExtraForbidModel):
         description="List of beta features to enable. Make sure to check if the given feature is supported by the Claude deployment you are using.",
     )
     enable_citations: bool = False
-    web_search: WebSearchToolParam | None = Field(
-        default=None,
-        description=(
-            "Anthropic web search server-tool definition. "
-            "See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool"
-        ),
-    )
 
 
 class ClaudeConfigurationWithThinking(ClaudeConfiguration):

--- a/aidial_adapter_anthropic/adapter/_claude/converters.py
+++ b/aidial_adapter_anthropic/adapter/_claude/converters.py
@@ -331,17 +331,14 @@ def to_claude_tool_config(
         return None
 
     function_tools = [_to_claude_tool(tool) for tool in tools_config.tools]
-    web_search_tools = tools_config.build_web_search_tools()
+    web_search_tools = tools_config.web_search_tools
 
-    tools: list[ToolParam | WebSearchToolParam] = [
-        *function_tools,
-        *web_search_tools,
-    ]
+    tools: list[ToolParam | WebSearchToolParam] = (
+        function_tools + web_search_tools
+    )
     if not tools:
         return None
 
-    # Server tools (e.g. web search) must not force a tool_choice,
-    # so tool_choice is only derived from the function tools.
     tool_choice = (
         _to_claude_tool_choice(tools_config.tool_choice)
         if function_tools

--- a/aidial_adapter_anthropic/adapter/_claude/converters.py
+++ b/aidial_adapter_anthropic/adapter/_claude/converters.py
@@ -61,6 +61,7 @@ from aidial_adapter_anthropic.dial._message import (
     SystemMessage,
 )
 from aidial_adapter_anthropic.dial.request import ModelParameters
+from aidial_adapter_anthropic.dial.static_tools import parse_static_function
 from aidial_adapter_anthropic.dial.token_usage import TokenUsage
 from aidial_adapter_anthropic.dial.tools import ToolsConfig, ToolsMode
 
@@ -331,9 +332,11 @@ def to_claude_tool_config(
         return None
 
     function_tools = [_to_claude_tool(tool) for tool in tools_config.tools]
-    tools: list[ToolParam | WebSearchToolParam] = (
-        function_tools + tools_config.static_tools
-    )
+    static_tools = [
+        parse_static_function(str(idx), tool.static_function)
+        for idx, tool in enumerate(tools_config.static_tools)
+    ]
+    tools: list[ToolParam | WebSearchToolParam] = function_tools + static_tools
     if not tools:
         return None
 

--- a/aidial_adapter_anthropic/adapter/_claude/converters.py
+++ b/aidial_adapter_anthropic/adapter/_claude/converters.py
@@ -43,6 +43,7 @@ from aidial_adapter_anthropic.adapter._claude.config import (
     ClaudeEffort,
     Configuration,
 )
+from aidial_adapter_anthropic.adapter._claude.params import WebSearchToolParam
 from aidial_adapter_anthropic.adapter._claude.state import (
     get_message_content_from_state,
 )
@@ -319,18 +320,33 @@ def _to_claude_tool_choice(
 
 @dataclass
 class ClaudeToolsConfig:
-    tools: list[ToolParam]
-    tool_choice: ToolChoice
+    tools: list[ToolParam | WebSearchToolParam]
+    tool_choice: ToolChoice | None
 
 
 def to_claude_tool_config(
     tools_config: ToolsConfig | None,
 ) -> ClaudeToolsConfig | None:
-    if tools_config is None or not tools_config.tools:
+    if tools_config is None:
         return None
 
-    tools = [_to_claude_tool(tool) for tool in tools_config.tools]
-    tool_choice = _to_claude_tool_choice(tools_config.tool_choice)
+    function_tools = [_to_claude_tool(tool) for tool in tools_config.tools]
+    web_search_tools = tools_config.build_web_search_tools()
+
+    tools: list[ToolParam | WebSearchToolParam] = [
+        *function_tools,
+        *web_search_tools,
+    ]
+    if not tools:
+        return None
+
+    # Server tools (e.g. web search) must not force a tool_choice,
+    # so tool_choice is only derived from the function tools.
+    tool_choice = (
+        _to_claude_tool_choice(tools_config.tool_choice)
+        if function_tools
+        else None
+    )
     return ClaudeToolsConfig(tools=tools, tool_choice=tool_choice)
 
 

--- a/aidial_adapter_anthropic/adapter/_claude/converters.py
+++ b/aidial_adapter_anthropic/adapter/_claude/converters.py
@@ -331,10 +331,8 @@ def to_claude_tool_config(
         return None
 
     function_tools = [_to_claude_tool(tool) for tool in tools_config.tools]
-    web_search_tools = tools_config.web_search_tools
-
     tools: list[ToolParam | WebSearchToolParam] = (
-        function_tools + web_search_tools
+        function_tools + tools_config.static_tools
     )
     if not tools:
         return None

--- a/aidial_adapter_anthropic/dial/static_tools.py
+++ b/aidial_adapter_anthropic/dial/static_tools.py
@@ -1,0 +1,43 @@
+from typing import Literal
+
+import pydantic
+from aidial_sdk.chat_completion.request import StaticFunction
+from anthropic.types.beta import (
+    BetaWebSearchTool20250305Param,
+    BetaWebSearchTool20260209Param,
+)
+
+from aidial_adapter_anthropic.adapter._errors import ValidationError
+
+WebSearchToolParam = (
+    BetaWebSearchTool20250305Param | BetaWebSearchTool20260209Param
+)
+
+
+class WebSearchTool(pydantic.BaseModel):
+    name: Literal["web_search"]
+    configuration: WebSearchToolParam
+
+
+def parse_static_function(idx: str, func: StaticFunction) -> WebSearchToolParam:
+    """
+    Convert the ``web_search`` static function into the Anthropic web search
+    server-tool definition. The ``name`` is defaulted from the static function
+    so clients don't have to repeat it inside the configuration.
+
+    See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool
+    """
+    config = dict(func.configuration or {})
+    name = config["name"] = config.get("name") or func.name
+    obj = {"name": name, "configuration": config}
+
+    try:
+        tool = WebSearchTool.model_validate(obj)
+        return tool.configuration
+    except pydantic.ValidationError as e:
+        error = e.errors()[0]
+        path = ".".join(map(str, error["loc"]))
+        raise ValidationError(
+            "Invalid static tool definition at "
+            f"'tools[{idx}].static_function.{path}': {error['msg']}"
+        ) from None

--- a/aidial_adapter_anthropic/dial/tools.py
+++ b/aidial_adapter_anthropic/dial/tools.py
@@ -42,10 +42,6 @@ class ToolsMode(Enum):
 class StaticToolName(str, Enum):
     """
     Names of the server-side (static) tools supported by the adapter.
-
-    Static tools are activated via the OpenAI-protocol static function
-    signature (``type: "static_function"``) instead of ordinary function
-    tools, and are executed on Anthropic's side.
     """
 
     WEB_SEARCH = "web_search"

--- a/aidial_adapter_anthropic/dial/tools.py
+++ b/aidial_adapter_anthropic/dial/tools.py
@@ -35,7 +35,7 @@ class ToolsConfig(BaseModel):
     List of functions/tools.
     """
 
-    static_tools: list[StaticTool] = []
+    static_tools: list[StaticTool]
     """
     List of server-side (static) tools, e.g. web search.
     Executed on the provider's side rather than round-tripped to the client.

--- a/aidial_adapter_anthropic/dial/tools.py
+++ b/aidial_adapter_anthropic/dial/tools.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Literal, Self
+from typing import Literal, Self, assert_never
 
 from aidial_sdk.chat_completion import (
     Function,
@@ -17,10 +17,6 @@ from aidial_sdk.chat_completion.request import (
 from pydantic import BaseModel
 
 from aidial_adapter_anthropic.adapter._errors import ValidationError
-from aidial_adapter_anthropic.dial.static_tools import (
-    WebSearchToolParam,
-    parse_static_function,
-)
 
 _log = logging.getLogger(__name__)
 
@@ -39,7 +35,7 @@ class ToolsConfig(BaseModel):
     List of functions/tools.
     """
 
-    static_tools: list[WebSearchToolParam] = []
+    static_tools: list[StaticTool] = []
     """
     List of server-side (static) tools, e.g. web search.
     Executed on the provider's side rather than round-tripped to the client.
@@ -90,18 +86,19 @@ class ToolsConfig(BaseModel):
     @staticmethod
     def _split_tools(
         tools: list[Function] | list[Tool | StaticTool],
-    ) -> tuple[list[Tool], list[WebSearchToolParam]]:
+    ) -> tuple[list[Tool], list[StaticTool]]:
         function_tools: list[Tool] = []
-        static_tools: list[WebSearchToolParam] = []
-        for idx, tool in enumerate(tools):
-            if isinstance(tool, StaticTool):
-                static_tools.append(
-                    parse_static_function(str(idx), tool.static_function)
-                )
-            elif isinstance(tool, Function):
-                function_tools.append(Tool(type="function", function=tool))
-            else:
-                function_tools.append(tool)
+        static_tools: list[StaticTool] = []
+        for tool in tools:
+            match tool:
+                case StaticTool():
+                    static_tools.append(tool)
+                case Function():
+                    function_tools.append(Tool(type="function", function=tool))
+                case Tool():
+                    function_tools.append(tool)
+                case _:
+                    assert_never(tool)
         return function_tools, static_tools
 
     @classmethod
@@ -110,7 +107,7 @@ class ToolsConfig(BaseModel):
 
         tool_ids = _collect_tool_ids(request.messages)
 
-        static_tools: list[WebSearchToolParam] = []
+        static_tools: list[StaticTool] = []
 
         if request.functions is not None:
             tools_mode = ToolsMode.FUNCTIONS

--- a/aidial_adapter_anthropic/dial/tools.py
+++ b/aidial_adapter_anthropic/dial/tools.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Any, Literal, Self
+from typing import Literal, Self
 
 from aidial_sdk.chat_completion import (
     Function,
@@ -12,20 +12,14 @@ from aidial_sdk.chat_completion import (
 )
 from aidial_sdk.chat_completion.request import (
     AzureChatCompletionRequest,
-    StaticFunction,
     StaticTool,
 )
-from anthropic.types.beta import (
-    BetaWebSearchTool20250305Param,
-    BetaWebSearchTool20260209Param,
-)
-from pydantic import BaseModel, TypeAdapter
-from pydantic import ValidationError as PydanticValidationError
+from pydantic import BaseModel
 
 from aidial_adapter_anthropic.adapter._errors import ValidationError
-
-WebSearchToolParam = (
-    BetaWebSearchTool20250305Param | BetaWebSearchTool20260209Param
+from aidial_adapter_anthropic.dial.static_tools import (
+    WebSearchToolParam,
+    parse_static_function,
 )
 
 _log = logging.getLogger(__name__)
@@ -39,48 +33,13 @@ class ToolsMode(Enum):
     """
 
 
-class StaticToolName(str, Enum):
-    """
-    Names of the server-side (static) tools supported by the adapter.
-    """
-
-    WEB_SEARCH = "web_search"
-
-
-_web_search_tool_adapter: TypeAdapter[WebSearchToolParam] = TypeAdapter(
-    WebSearchToolParam
-)
-
-
-def _to_web_search_tool(static_function: StaticFunction) -> WebSearchToolParam:
-    """
-    Convert the ``web_search`` static function into the Anthropic web search
-    server-tool definition. The ``name`` is defaulted from the static function
-    so clients don't have to repeat it inside the configuration.
-
-    See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool
-    """
-    config: dict[str, Any] = dict(static_function.configuration or {})
-    config.setdefault("name", static_function.name)
-
-    try:
-        return _web_search_tool_adapter.validate_python(config)
-    except PydanticValidationError as e:
-        error = e.errors()[0]
-        path = ".".join(map(str, error["loc"]))
-        raise ValidationError(
-            "Invalid web search tool definition at "
-            f"'static_function.configuration.{path}': {error['msg']}"
-        ) from None
-
-
 class ToolsConfig(BaseModel):
     tools: list[Tool]
     """
     List of functions/tools.
     """
 
-    static_tools: list[StaticTool] = []
+    web_search_tools: list[WebSearchToolParam] = []
     """
     List of server-side (static) tools, e.g. web search.
     Executed on the provider's side rather than round-tripped to the client.
@@ -97,18 +56,11 @@ class ToolsConfig(BaseModel):
     """
 
     def not_supported(self) -> None:
-        if not self.tools and not self.static_tools:
+        if not self.tools and not self.web_search_tools:
             return
         if self.tools_mode == ToolsMode.TOOLS:
             raise ValidationError("The tools aren't supported")
         raise ValidationError("The functions aren't supported")
-
-    def build_web_search_tools(self) -> list[WebSearchToolParam]:
-        return [
-            _to_web_search_tool(tool.static_function)
-            for tool in self.static_tools
-            if tool.static_function.name == StaticToolName.WEB_SEARCH.value
-        ]
 
     def create_fresh_tool_call_id(self, tool_name: str) -> str:
         idx = 1
@@ -136,31 +88,21 @@ class ToolsConfig(BaseModel):
                 return function_call
 
     @staticmethod
-    def _validate_static_tool(tool: StaticTool) -> StaticTool:
-        name = tool.static_function.name
-        supported = [t.value for t in StaticToolName]
-        if name not in supported:
-            raise ValidationError(
-                f"Unsupported static tool: {name!r}. "
-                f"Supported static tools: {supported}."
-            )
-        return tool
-
-    @classmethod
     def _split_tools(
-        cls,
         tools: list[Function] | list[Tool | StaticTool],
-    ) -> tuple[list[Tool], list[StaticTool]]:
+    ) -> tuple[list[Tool], list[WebSearchToolParam]]:
         function_tools: list[Tool] = []
-        static_tools: list[StaticTool] = []
-        for tool in tools:
+        web_search_tools: list[WebSearchToolParam] = []
+        for idx, tool in enumerate(tools):
             if isinstance(tool, StaticTool):
-                static_tools.append(cls._validate_static_tool(tool))
+                web_search_tools.append(
+                    parse_static_function(str(idx), tool.static_function)
+                )
             elif isinstance(tool, Function):
                 function_tools.append(Tool(type="function", function=tool))
             else:
                 function_tools.append(tool)
-        return function_tools, static_tools
+        return function_tools, web_search_tools
 
     @classmethod
     def from_request(cls, request: AzureChatCompletionRequest) -> Self | None:
@@ -168,17 +110,17 @@ class ToolsConfig(BaseModel):
 
         tool_ids = _collect_tool_ids(request.messages)
 
-        static_tools: list[StaticTool] = []
+        web_search_tools: list[WebSearchToolParam] = []
 
         if request.functions is not None:
             tools_mode = ToolsMode.FUNCTIONS
-            tools, static_tools = cls._split_tools(request.functions)
+            tools, web_search_tools = cls._split_tools(request.functions)
             tool_choice = cls._function_call_to_tool_choice(
                 request.function_call
             )
         elif request.tools is not None:
             tools_mode = ToolsMode.TOOLS
-            tools, static_tools = cls._split_tools(request.tools)
+            tools, web_search_tools = cls._split_tools(request.tools)
             tool_choice = request.tool_choice
         elif tool_ids:
             tools_mode = ToolsMode.TOOLS
@@ -189,7 +131,7 @@ class ToolsConfig(BaseModel):
 
         return cls(
             tools=tools,
-            static_tools=static_tools,
+            web_search_tools=web_search_tools,
             tools_mode=tools_mode,
             tool_choice=tool_choice or "auto",
             tool_ids=tool_ids,

--- a/aidial_adapter_anthropic/dial/tools.py
+++ b/aidial_adapter_anthropic/dial/tools.py
@@ -39,7 +39,7 @@ class ToolsConfig(BaseModel):
     List of functions/tools.
     """
 
-    web_search_tools: list[WebSearchToolParam] = []
+    static_tools: list[WebSearchToolParam] = []
     """
     List of server-side (static) tools, e.g. web search.
     Executed on the provider's side rather than round-tripped to the client.
@@ -56,7 +56,7 @@ class ToolsConfig(BaseModel):
     """
 
     def not_supported(self) -> None:
-        if not self.tools and not self.web_search_tools:
+        if not self.tools and not self.static_tools:
             return
         if self.tools_mode == ToolsMode.TOOLS:
             raise ValidationError("The tools aren't supported")
@@ -92,17 +92,17 @@ class ToolsConfig(BaseModel):
         tools: list[Function] | list[Tool | StaticTool],
     ) -> tuple[list[Tool], list[WebSearchToolParam]]:
         function_tools: list[Tool] = []
-        web_search_tools: list[WebSearchToolParam] = []
+        static_tools: list[WebSearchToolParam] = []
         for idx, tool in enumerate(tools):
             if isinstance(tool, StaticTool):
-                web_search_tools.append(
+                static_tools.append(
                     parse_static_function(str(idx), tool.static_function)
                 )
             elif isinstance(tool, Function):
                 function_tools.append(Tool(type="function", function=tool))
             else:
                 function_tools.append(tool)
-        return function_tools, web_search_tools
+        return function_tools, static_tools
 
     @classmethod
     def from_request(cls, request: AzureChatCompletionRequest) -> Self | None:
@@ -110,17 +110,17 @@ class ToolsConfig(BaseModel):
 
         tool_ids = _collect_tool_ids(request.messages)
 
-        web_search_tools: list[WebSearchToolParam] = []
+        static_tools: list[WebSearchToolParam] = []
 
         if request.functions is not None:
             tools_mode = ToolsMode.FUNCTIONS
-            tools, web_search_tools = cls._split_tools(request.functions)
+            tools, static_tools = cls._split_tools(request.functions)
             tool_choice = cls._function_call_to_tool_choice(
                 request.function_call
             )
         elif request.tools is not None:
             tools_mode = ToolsMode.TOOLS
-            tools, web_search_tools = cls._split_tools(request.tools)
+            tools, static_tools = cls._split_tools(request.tools)
             tool_choice = request.tool_choice
         elif tool_ids:
             tools_mode = ToolsMode.TOOLS
@@ -131,7 +131,7 @@ class ToolsConfig(BaseModel):
 
         return cls(
             tools=tools,
-            web_search_tools=web_search_tools,
+            static_tools=static_tools,
             tools_mode=tools_mode,
             tool_choice=tool_choice or "auto",
             tool_ids=tool_ids,

--- a/aidial_adapter_anthropic/dial/tools.py
+++ b/aidial_adapter_anthropic/dial/tools.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Literal, Self
+from typing import Any, Literal, Self
 
 from aidial_sdk.chat_completion import (
     Function,
@@ -12,11 +12,21 @@ from aidial_sdk.chat_completion import (
 )
 from aidial_sdk.chat_completion.request import (
     AzureChatCompletionRequest,
+    StaticFunction,
     StaticTool,
 )
-from pydantic import BaseModel
+from anthropic.types.beta import (
+    BetaWebSearchTool20250305Param,
+    BetaWebSearchTool20260209Param,
+)
+from pydantic import BaseModel, TypeAdapter
+from pydantic import ValidationError as PydanticValidationError
 
 from aidial_adapter_anthropic.adapter._errors import ValidationError
+
+WebSearchToolParam = (
+    BetaWebSearchTool20250305Param | BetaWebSearchTool20260209Param
+)
 
 _log = logging.getLogger(__name__)
 
@@ -29,10 +39,55 @@ class ToolsMode(Enum):
     """
 
 
+class StaticToolName(str, Enum):
+    """
+    Names of the server-side (static) tools supported by the adapter.
+
+    Static tools are activated via the OpenAI-protocol static function
+    signature (``type: "static_function"``) instead of ordinary function
+    tools, and are executed on Anthropic's side.
+    """
+
+    WEB_SEARCH = "web_search"
+
+
+_web_search_tool_adapter: TypeAdapter[WebSearchToolParam] = TypeAdapter(
+    WebSearchToolParam
+)
+
+
+def _to_web_search_tool(static_function: StaticFunction) -> WebSearchToolParam:
+    """
+    Convert the ``web_search`` static function into the Anthropic web search
+    server-tool definition. The ``name`` is defaulted from the static function
+    so clients don't have to repeat it inside the configuration.
+
+    See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool
+    """
+    config: dict[str, Any] = dict(static_function.configuration or {})
+    config.setdefault("name", static_function.name)
+
+    try:
+        return _web_search_tool_adapter.validate_python(config)
+    except PydanticValidationError as e:
+        error = e.errors()[0]
+        path = ".".join(map(str, error["loc"]))
+        raise ValidationError(
+            "Invalid web search tool definition at "
+            f"'static_function.configuration.{path}': {error['msg']}"
+        ) from None
+
+
 class ToolsConfig(BaseModel):
     tools: list[Tool]
     """
     List of functions/tools.
+    """
+
+    static_tools: list[StaticTool] = []
+    """
+    List of server-side (static) tools, e.g. web search.
+    Executed on the provider's side rather than round-tripped to the client.
     """
 
     tools_mode: ToolsMode
@@ -46,11 +101,18 @@ class ToolsConfig(BaseModel):
     """
 
     def not_supported(self) -> None:
-        if not self.tools:
+        if not self.tools and not self.static_tools:
             return
         if self.tools_mode == ToolsMode.TOOLS:
             raise ValidationError("The tools aren't supported")
         raise ValidationError("The functions aren't supported")
+
+    def build_web_search_tools(self) -> list[WebSearchToolParam]:
+        return [
+            _to_web_search_tool(tool.static_function)
+            for tool in self.static_tools
+            if tool.static_function.name == StaticToolName.WEB_SEARCH.value
+        ]
 
     def create_fresh_tool_call_id(self, tool_name: str) -> str:
         idx = 1
@@ -78,19 +140,31 @@ class ToolsConfig(BaseModel):
                 return function_call
 
     @staticmethod
-    def _get_tool_from_function(tool: Function | Tool | StaticTool) -> Tool:
-        if isinstance(tool, StaticTool):
-            raise ValidationError("Static tools aren't supported")
-        if isinstance(tool, Function):
-            return Tool(type="function", function=tool)
-        else:
-            return tool
+    def _validate_static_tool(tool: StaticTool) -> StaticTool:
+        name = tool.static_function.name
+        supported = [t.value for t in StaticToolName]
+        if name not in supported:
+            raise ValidationError(
+                f"Unsupported static tool: {name!r}. "
+                f"Supported static tools: {supported}."
+            )
+        return tool
 
-    @staticmethod
-    def _get_tools_from_functions(
+    @classmethod
+    def _split_tools(
+        cls,
         tools: list[Function] | list[Tool | StaticTool],
-    ) -> list[Tool]:
-        return [ToolsConfig._get_tool_from_function(tool) for tool in tools]
+    ) -> tuple[list[Tool], list[StaticTool]]:
+        function_tools: list[Tool] = []
+        static_tools: list[StaticTool] = []
+        for tool in tools:
+            if isinstance(tool, StaticTool):
+                static_tools.append(cls._validate_static_tool(tool))
+            elif isinstance(tool, Function):
+                function_tools.append(Tool(type="function", function=tool))
+            else:
+                function_tools.append(tool)
+        return function_tools, static_tools
 
     @classmethod
     def from_request(cls, request: AzureChatCompletionRequest) -> Self | None:
@@ -98,15 +172,17 @@ class ToolsConfig(BaseModel):
 
         tool_ids = _collect_tool_ids(request.messages)
 
+        static_tools: list[StaticTool] = []
+
         if request.functions is not None:
             tools_mode = ToolsMode.FUNCTIONS
-            tools = cls._get_tools_from_functions(request.functions)
+            tools, static_tools = cls._split_tools(request.functions)
             tool_choice = cls._function_call_to_tool_choice(
                 request.function_call
             )
         elif request.tools is not None:
             tools_mode = ToolsMode.TOOLS
-            tools = cls._get_tools_from_functions(request.tools)
+            tools, static_tools = cls._split_tools(request.tools)
             tool_choice = request.tool_choice
         elif tool_ids:
             tools_mode = ToolsMode.TOOLS
@@ -117,6 +193,7 @@ class ToolsConfig(BaseModel):
 
         return cls(
             tools=tools,
+            static_tools=static_tools,
             tools_mode=tools_mode,
             tool_choice=tool_choice or "auto",
             tool_ids=tool_ids,

--- a/tests/unit_tests/test_claude_truncate_prompt.py
+++ b/tests/unit_tests/test_claude_truncate_prompt.py
@@ -86,6 +86,7 @@ def _index_range(start: int, end: int) -> list[int]:
 
 _TOOL_CONFIG = ToolsConfig(
     tools=[Tool(type="function", function=Function(name="function"))],
+    static_tools=[],
     tool_choice="auto",
     tool_ids={},
     tools_mode=ToolsMode.TOOLS,

--- a/tests/unit_tests/test_configuration.py
+++ b/tests/unit_tests/test_configuration.py
@@ -135,7 +135,6 @@ async def test_configuration_schema_top_level_properties(adapter: Adapter):
     assert props == {
         "betas",
         "enable_citations",
-        "web_search",
         "thinking",
         "effort",
     }

--- a/tests/unit_tests/test_tools.py
+++ b/tests/unit_tests/test_tools.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 import pytest
 from aidial_sdk.chat_completion.request import AzureChatCompletionRequest
-from aidial_sdk.exceptions import RequestValidationError
 from anthropic import Omit
 from openai.types.chat import ChatCompletionToolParam
 
+from aidial_adapter_anthropic.adapter import ValidationError
 from aidial_adapter_anthropic.adapter._claude.adapter import Adapter
 from aidial_adapter_anthropic.adapter._claude.converters import (
     to_claude_tool_config,
@@ -16,9 +18,8 @@ from tests.utils.openai import (
     user,
 )
 
-WEB_SEARCH_TOOL_REQUEST = {
+WEB_SEARCH_CONFIGURATION = {
     "type": "web_search_20250305",
-    "name": "web_search",
     "max_uses": 5,
     "allowed_domains": ["example.com", "example.org"],
     "user_location": {
@@ -29,6 +30,23 @@ WEB_SEARCH_TOOL_REQUEST = {
         "timezone": "America/Los_Angeles",
     },
 }
+
+# The `name` is defaulted from the static function name.
+WEB_SEARCH_TOOL_REQUEST = {**WEB_SEARCH_CONFIGURATION, "name": "web_search"}
+
+
+def web_search_static_tool(configuration: dict | None = None) -> dict:
+    static_function: dict = {"name": "web_search"}
+    if configuration is not None:
+        static_function["configuration"] = configuration
+    return {"type": "static_function", "static_function": static_function}
+
+
+def _tool_config(tools: list[Any]) -> ToolsConfig | None:
+    request = AzureChatCompletionRequest.model_validate(
+        {"messages": [], "tools": tools}
+    )
+    return ToolsConfig.from_request(request)
 
 
 def _run_schema_references_check(tool: ChatCompletionToolParam, has_refs: bool):
@@ -45,7 +63,8 @@ def _run_schema_references_check(tool: ChatCompletionToolParam, has_refs: bool):
     claude_tools = to_claude_tool_config(dial_tools)
     assert claude_tools is not None
 
-    assert ("$defs" in claude_tools.tools[0]["input_schema"]) == has_refs
+    function_tool: Any = claude_tools.tools[0]
+    assert ("$defs" in function_tool["input_schema"]) == has_refs
 
 
 def test_tools_schemas_with_references():
@@ -61,18 +80,27 @@ def test_tools_schemas_without_references():
     ["web_search_20250305", "web_search_20260209"],
 )
 async def test_web_search_minimal_passthrough(adapter: Adapter, tool_type: str):
-    tool = {"type": tool_type, "name": "web_search"}
     request = await adapter._prepare_claude_request(
-        ModelParameters(configuration={"web_search": tool}),
+        ModelParameters(
+            tool_config=_tool_config(
+                [web_search_static_tool({"type": tool_type})]
+            )
+        ),
         [user("What is the weather in NYC?")],
     )
 
-    assert request.params["tools"] == [tool]
+    assert request.params["tools"] == [
+        {"type": tool_type, "name": "web_search"}
+    ]
 
 
 async def test_web_search_all_optional_fields_preserved(adapter: Adapter):
     request = await adapter._prepare_claude_request(
-        ModelParameters(configuration={"web_search": WEB_SEARCH_TOOL_REQUEST}),
+        ModelParameters(
+            tool_config=_tool_config(
+                [web_search_static_tool(WEB_SEARCH_CONFIGURATION)]
+            )
+        ),
         [user("What is the weather in NYC?")],
     )
 
@@ -84,7 +112,11 @@ async def test_web_search_all_optional_fields_preserved(adapter: Adapter):
 async def test_web_search_tool_choice_left_default(adapter: Adapter):
     # Web search is a server tool: enabling it must not force a tool_choice.
     request = await adapter._prepare_claude_request(
-        ModelParameters(configuration={"web_search": WEB_SEARCH_TOOL_REQUEST}),
+        ModelParameters(
+            tool_config=_tool_config(
+                [web_search_static_tool(WEB_SEARCH_CONFIGURATION)]
+            )
+        ),
         [user("hello")],
     )
 
@@ -92,15 +124,14 @@ async def test_web_search_tool_choice_left_default(adapter: Adapter):
 
 
 async def test_web_search_appended_after_function_tools(adapter: Adapter):
-    dial_request = AzureChatCompletionRequest.model_validate(
-        {"messages": [], "tools": [GET_WEATHER_TOOL]}
-    )
-    tool_config = ToolsConfig.from_request(dial_request)
-
     request = await adapter._prepare_claude_request(
         ModelParameters(
-            configuration={"web_search": WEB_SEARCH_TOOL_REQUEST},
-            tool_config=tool_config,
+            tool_config=_tool_config(
+                [
+                    GET_WEATHER_TOOL,
+                    web_search_static_tool(WEB_SEARCH_CONFIGURATION),
+                ]
+            ),
         ),
         [user("What is the weather in NYC?")],
     )
@@ -121,20 +152,38 @@ async def test_no_web_search_keeps_tools_omitted(adapter: Adapter):
     assert isinstance(request.params["tools"], Omit)
 
 
-@pytest.mark.parametrize(
-    "invalid_tool",
-    [
-        pytest.param({"name": "web_search"}, id="missing-type"),
-        pytest.param({"type": "web_search_20250305"}, id="missing-name"),
-    ],
-)
-async def test_web_search_invalid_definition_rejected(
-    adapter: Adapter, invalid_tool: dict
-):
+async def test_web_search_invalid_definition_rejected(adapter: Adapter):
+    # Missing the required `type` discriminator.
     request = adapter._prepare_claude_request(
-        ModelParameters(configuration={"web_search": invalid_tool}),
+        ModelParameters(
+            tool_config=_tool_config([web_search_static_tool({"max_uses": 5})])
+        ),
         [user("hello")],
     )
 
-    with pytest.raises(RequestValidationError):
+    with pytest.raises(ValidationError):
         await request
+
+
+def test_unsupported_static_tool_rejected():
+    with pytest.raises(ValidationError, match="Unsupported static tool"):
+        _tool_config(
+            [
+                {
+                    "type": "static_function",
+                    "static_function": {"name": "code_execution"},
+                }
+            ]
+        )
+
+
+def test_web_search_static_tool_kept_out_of_function_tools():
+    tool_config = _tool_config(
+        [web_search_static_tool({"type": "web_search_20250305"})]
+    )
+    assert tool_config is not None
+    assert tool_config.tools == []
+    assert len(tool_config.static_tools) == 1
+    assert tool_config.build_web_search_tools() == [
+        {"type": "web_search_20250305", "name": "web_search"}
+    ]

--- a/tests/unit_tests/test_tools.py
+++ b/tests/unit_tests/test_tools.py
@@ -153,7 +153,6 @@ async def test_no_web_search_keeps_tools_omitted(adapter: Adapter):
 
 
 async def test_web_search_invalid_definition_rejected(adapter: Adapter):
-    # Missing the required `type` discriminator.
     request = adapter._prepare_claude_request(
         ModelParameters(
             tool_config=_tool_config([web_search_static_tool({"max_uses": 5})])

--- a/tests/unit_tests/test_tools.py
+++ b/tests/unit_tests/test_tools.py
@@ -153,7 +153,6 @@ async def test_no_web_search_keeps_tools_omitted(adapter: Adapter):
 
 
 def test_web_search_invalid_definition_rejected():
-    # A web search definition missing the required `type` discriminator.
     match = (
         r"Invalid static tool definition at "
         r"'tools\[0\]\.static_function\.configuration.*': Field required"
@@ -184,6 +183,6 @@ def test_web_search_static_tool_kept_out_of_function_tools():
     )
     assert tool_config is not None
     assert tool_config.tools == []
-    assert tool_config.web_search_tools == [
+    assert tool_config.static_tools == [
         {"type": "web_search_20250305", "name": "web_search"}
     ]

--- a/tests/unit_tests/test_tools.py
+++ b/tests/unit_tests/test_tools.py
@@ -152,20 +152,22 @@ async def test_no_web_search_keeps_tools_omitted(adapter: Adapter):
     assert isinstance(request.params["tools"], Omit)
 
 
-async def test_web_search_invalid_definition_rejected(adapter: Adapter):
-    request = adapter._prepare_claude_request(
-        ModelParameters(
-            tool_config=_tool_config([web_search_static_tool({"max_uses": 5})])
-        ),
-        [user("hello")],
+def test_web_search_invalid_definition_rejected():
+    # A web search definition missing the required `type` discriminator.
+    match = (
+        r"Invalid static tool definition at "
+        r"'tools\[0\]\.static_function\.configuration.*': Field required"
     )
-
-    with pytest.raises(ValidationError):
-        await request
+    with pytest.raises(ValidationError, match=match):
+        _tool_config([web_search_static_tool({"max_uses": 5})])
 
 
 def test_unsupported_static_tool_rejected():
-    with pytest.raises(ValidationError, match="Unsupported static tool"):
+    match = (
+        r"Invalid static tool definition at "
+        r"'tools\[0\]\.static_function\.name': Input should be 'web_search'"
+    )
+    with pytest.raises(ValidationError, match=match):
         _tool_config(
             [
                 {
@@ -182,7 +184,6 @@ def test_web_search_static_tool_kept_out_of_function_tools():
     )
     assert tool_config is not None
     assert tool_config.tools == []
-    assert len(tool_config.static_tools) == 1
-    assert tool_config.build_web_search_tools() == [
+    assert tool_config.web_search_tools == [
         {"type": "web_search_20250305", "name": "web_search"}
     ]

--- a/tests/unit_tests/test_tools.py
+++ b/tests/unit_tests/test_tools.py
@@ -153,12 +153,15 @@ async def test_no_web_search_keeps_tools_omitted(adapter: Adapter):
 
 
 def test_web_search_invalid_definition_rejected():
+    # A web search definition missing the required `type` discriminator.
     match = (
         r"Invalid static tool definition at "
         r"'tools\[0\]\.static_function\.configuration.*': Field required"
     )
     with pytest.raises(ValidationError, match=match):
-        _tool_config([web_search_static_tool({"max_uses": 5})])
+        to_claude_tool_config(
+            _tool_config([web_search_static_tool({"max_uses": 5})])
+        )
 
 
 def test_unsupported_static_tool_rejected():
@@ -167,13 +170,15 @@ def test_unsupported_static_tool_rejected():
         r"'tools\[0\]\.static_function\.name': Input should be 'web_search'"
     )
     with pytest.raises(ValidationError, match=match):
-        _tool_config(
-            [
-                {
-                    "type": "static_function",
-                    "static_function": {"name": "code_execution"},
-                }
-            ]
+        to_claude_tool_config(
+            _tool_config(
+                [
+                    {
+                        "type": "static_function",
+                        "static_function": {"name": "code_execution"},
+                    }
+                ]
+            )
         )
 
 
@@ -183,6 +188,10 @@ def test_web_search_static_tool_kept_out_of_function_tools():
     )
     assert tool_config is not None
     assert tool_config.tools == []
-    assert tool_config.static_tools == [
+    assert len(tool_config.static_tools) == 1
+
+    claude_tools = to_claude_tool_config(tool_config)
+    assert claude_tools is not None
+    assert claude_tools.tools == [
         {"type": "web_search_20250305", "name": "web_search"}
     ]


### PR DESCRIPTION
## Summary

Reworks Claude web search activation from `custom_fields.configuration.web_search` to the OpenAI-protocol **static tool** signature, and moves the static-tool handling into the shared `dial/tools.py` package so downstream adapters need only bump the version.

This is a **breaking change**: the `configuration.web_search` field is removed.

Follow-up to #69.

## Changes

- **Static tool support (`dial/tools.py`):** `ToolsConfig` now recognizes `type: "static_function"` tools, validates their names against a `StaticToolName` registry (rejecting unknown ones), keeps them separate from function tools, and converts `web_search` into the Anthropic web search tool param. `name` is defaulted from the static function so clients don't repeat it.
- **Adapter (`adapter/_claude/`):** removed the `configuration.web_search` field and its handling; web search tools now come from the tool config. `to_claude_tool_config` appends server tools without forcing a `tool_choice`.
- **Docs:** README web search section rewritten to the static-tool request signature (basic + optional-fields examples).
- **Tests:** web search tests migrated to the static-tool signature; added coverage for unsupported static-tool rejection and function/static-tool separation; configuration schema assertion updated.